### PR TITLE
Add support for @sap/eslint-plugin-cds

### DIFF
--- a/src/examples/plugin-cds/MetaItem.vue
+++ b/src/examples/plugin-cds/MetaItem.vue
@@ -1,0 +1,12 @@
+<script lang="ts">
+export const name = "@sap/eslint-plugin-cds";
+</script>
+<script setup lang="ts">
+const pluginName = name;
+</script>
+<template>
+  <div>
+    Example to try
+    <a href="https://www.npmjs.com/package/@sap/eslint-plugin-cds" target="_blank">{{ pluginName }}</a>
+  </div>
+</template>

--- a/src/examples/plugin-cds/_eslintrc.json.ts
+++ b/src/examples/plugin-cds/_eslintrc.json.ts
@@ -1,0 +1,7 @@
+export default {
+  extends: ["plugin:@sap/cds/recommended"],
+  rules: {
+    "no-console": "error",
+    "@sap/cds/start-entities-uppercase": "warn",
+  },
+};

--- a/src/examples/plugin-cds/meta.ts
+++ b/src/examples/plugin-cds/meta.ts
@@ -1,0 +1,1 @@
+export { default as description, name } from "./MetaItem.vue";

--- a/src/examples/plugin-cds/package.json.ts
+++ b/src/examples/plugin-cds/package.json.ts
@@ -1,0 +1,7 @@
+export default {
+  devDependencies: {
+    eslint: "latest",
+    "@sap/eslint-plugin-cds": "latest",
+    "@sap/cds-dk": "latest",
+  },
+};

--- a/src/examples/plugin-cds/src/example.cds.txt
+++ b/src/examples/plugin-cds/src/example.cds.txt
@@ -1,0 +1,7 @@
+namespace sap.capire.bookshop;
+
+entity books {
+  key ID   : Integer;
+  title    : localized String(111);
+  descr    : localized String(1111);
+}

--- a/src/plugins/plugins/cds/plugin.ts
+++ b/src/plugins/plugins/cds/plugin.ts
@@ -1,0 +1,7 @@
+export const name = "@sap/eslint-plugin-cds";
+export const description =
+  "SAP Cloud Application Programming Model (CAP) model and environment linting rules";
+export const devDependencies = { [name]: "latest", "@sap/cds-dk": "latest" };
+export const eslintConfig = {
+  extends: ["plugin:@sap/cds/recommended"],
+};


### PR DESCRIPTION
- Adds plugin and example for [@sap/eslint-plugin-cds](https://www.npmjs.com/package/@sap/eslint-plugin-cds)

@ota-meshi: Thank you for providing/hosting an *ESLint Online Playground* for other plugins! 👏 I was wondering:
 - Are the generated URLs guaranteed to remain *stable*?
   - If so, we would like to link our current rule documentation examples to your playground via an **Open in Playground** button (as it is done in the ESLint documentation, see [example for *curly* rule](https://eslint.org/docs/latest/rules/curly#options)).