### PR TITLE
Update cds example

### DIFF
--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -38,7 +38,7 @@ export async function loadExamples(): Promise<Record<string, Example>> {
       },
     ),
     ...Object.entries(
-      import.meta.glob("./**/*.{txt,js}", {
+      import.meta.glob("./**/*.{txt,js,cds}", {
         as: "raw",
       }),
     ).map(async ([fileName, content]) => ({

--- a/src/examples/plugin-cds/_eslintrc.json.ts
+++ b/src/examples/plugin-cds/_eslintrc.json.ts
@@ -2,6 +2,6 @@ export default {
   extends: ["plugin:@sap/cds/recommended"],
   rules: {
     "no-console": "error",
-    "@sap/cds/start-entities-uppercase": "warn",
+    "@sap/cds/auth-restrict-grant-service": ["warn", "show"],
   },
 };

--- a/src/examples/plugin-cds/package.json.ts
+++ b/src/examples/plugin-cds/package.json.ts
@@ -1,7 +1,9 @@
 export default {
+  depencencies: {
+    "@sap/cds": "^7.0.0",
+  },
   devDependencies: {
     eslint: "latest",
     "@sap/eslint-plugin-cds": "latest",
-    "@sap/cds-dk": "latest",
   },
 };

--- a/src/examples/plugin-cds/src/db/schema.cds
+++ b/src/examples/plugin-cds/src/db/schema.cds
@@ -1,0 +1,13 @@
+namespace sap.capire.bookshop;
+
+entity Books {
+  key ID : Integer;
+  @mandatory title  : localized String(111);
+  @mandatory author : Association to Authors;
+}
+
+entity Authors {
+  key ID : Integer;
+  @mandatory name   : String(111);
+  books  : Association to many Books on books.author = $self;
+}

--- a/src/examples/plugin-cds/src/example.cds.txt
+++ b/src/examples/plugin-cds/src/example.cds.txt
@@ -1,7 +1,0 @@
-namespace sap.capire.bookshop;
-
-entity books {
-  key ID   : Integer;
-  title    : localized String(111);
-  descr    : localized String(1111);
-}

--- a/src/examples/plugin-cds/src/srv/cat-service.cds
+++ b/src/examples/plugin-cds/src/srv/cat-service.cds
@@ -1,0 +1,15 @@
+using { sap.capire.bookshop as my } from '../db/schema';
+
+service CatalogService {
+  @readonly entity ListOfBooks as projection on Books
+  excluding { descr };
+
+  @readonly entity Books as projection on my.Books { *,
+    author.name as author
+  } excluding { createdBy, modifiedBy };
+
+  @requires: 'authenticated-user'
+  action submitOrder ( book: Books:ID, quantity: Integer ) returns { stock: Integer };
+  event OrderedBook : { book: Books:ID; quantity: Integer; buyer: String };
+  function getViewsCount @(restrict: [{ grant: ['WRITE'], to: 'Admin' }]) () returns Integer;
+}

--- a/src/plugins/plugins/cds/plugin.ts
+++ b/src/plugins/plugins/cds/plugin.ts
@@ -3,7 +3,8 @@ import type { ESLintLegacyConfig } from "../..";
 export const name = "@sap/eslint-plugin-cds";
 export const description =
   "SAP Cloud Application Programming Model (CAP) model and environment linting rules";
-export const devDependencies = { [name]: "latest", "@sap/cds-dk": "latest" };
+export const depencencies = { "@sap/cds": "^7.0.0" };
+export const devDependencies = { [name]: "latest" };
 export const eslintLegacyConfig: ESLintLegacyConfig = {
   extends: ["plugin:@sap/cds/recommended"],
 };


### PR DESCRIPTION
- Adds a more representative example for `@sap/eslint-plugin-cds`:

<img width="991" alt="Screenshot 2024-04-05 at 18 13 52" src="https://github.com/ota-meshi/eslint-online-playground/assets/8320933/e5726139-05c3-4083-98d3-7325fe1725b3">
<br><br>

@ota-meshi: Given the example above, I was wondering whether it would be possible to have an extra parameter with which we could set the *initially selected* file, in this case `srv/cat-service.cds`. The current default would select the first src file `db/schema.cds`.

I found [this logic](https://github.com/ota-meshi/eslint-online-playground/blob/16dd775156945efe0cd02fc78faa6558feb3ee12/src/App.vue#L66-L75) and was wondering if I could contribute in some way to make this a bit more flexible?