### PR TITLE
Also lint .csv files for cds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "eslint.validate": [
+    "cds",
+    "csv",
+    "csv (semicolon)",
     "javascript",
     "javascriptreact",
     "typescript",

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -38,7 +38,7 @@ export async function loadExamples(): Promise<Record<string, Example>> {
       },
     ),
     ...Object.entries(
-      import.meta.glob("./**/*.{txt,js}", {
+      import.meta.glob("./**/*.{txt,js,cds,csv}", {
         as: "raw",
       }),
     ).map(async ([fileName, content]) => ({


### PR DESCRIPTION
- Support linting of `*.csv` files (for cds plugin) in VS Code
- Example:
<img width="667" alt="Screenshot 2024-04-08 at 06 29 42" src="https://github.com/ota-meshi/eslint-online-playground/assets/8320933/df137ded-5869-4426-8e7a-c7a8b04b78a2">
