### PR TITLE
Add Nick2bad4u ESLint plugin installers

### DIFF
--- a/src/plugins/plugins/nick2bad4u-copilot/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-copilot/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-copilot";
+export const meta: PluginMeta = {
+  description: "ESLint rules for GitHub Copilot repository customization files.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-copilot",
+  lang: ["markdown"],
+  package: "eslint-plugin-copilot",
+};
+export const devDependencies = { "eslint-plugin-copilot": "latest" };
+const importName = "copilot";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import copilot from 'eslint-plugin-copilot'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-copilot" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.spread(await helper.x(recommended));
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-docusaurus-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-docusaurus-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-docusaurus-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin for Docusaurus sites, docs repositories, and TypeDoc-integrated documentation workflows.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-docusaurus-2",
+  lang: ["javascript", "typescript", "markdown"],
+  package: "eslint-plugin-docusaurus-2",
+};
+export const devDependencies = { "eslint-plugin-docusaurus-2": "latest" };
+const importName = "docusaurus2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import docusaurus2 from 'eslint-plugin-docusaurus-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-docusaurus-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-etc-misc/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-etc-misc/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-etc-misc";
+export const meta: PluginMeta = {
+  description: "ESLint Plugin combining eslint-plugin-etc and eslint-plugin-misc.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-etc-misc",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-etc-misc",
+};
+export const devDependencies = { "eslint-plugin-etc-misc": "latest" };
+const importName = "etcMisc";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import etcMisc from 'eslint-plugin-etc-misc'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-etc-misc" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-file-progress-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-file-progress-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-file-progress-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin to print file progress.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-file-progress-2",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-file-progress-2",
+};
+export const devDependencies = { "eslint-plugin-file-progress-2": "latest" };
+const importName = "fileProgress2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import fileProgress2 from 'eslint-plugin-file-progress-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-file-progress-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-github-actions-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-github-actions-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-github-actions-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin for GitHub Actions workflow quality, reliability, and security rules.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-github-actions-2",
+  lang: ["yaml"],
+  package: "eslint-plugin-github-actions-2",
+};
+export const devDependencies = { "eslint-plugin-github-actions-2": "latest" };
+const importName = "githubActions2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import githubActions2 from 'eslint-plugin-github-actions-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-github-actions-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-immutable-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-immutable-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-immutable-2";
+export const meta: PluginMeta = {
+  description: "ESLint rules for enforcing immutable and functional code patterns.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-immutable-2",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-immutable-2",
+};
+export const devDependencies = { "eslint-plugin-immutable-2": "latest" };
+const importName = "immutable2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import immutable2 from 'eslint-plugin-immutable-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-immutable-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-json-schema-validator-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-json-schema-validator-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-json-schema-validator-2";
+export const meta: PluginMeta = {
+  description: "ESLint rules that validate JSON, YAML, TOML, JavaScript, and Vue custom-block data with JSON Schema.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-json-schema-validator-2",
+  lang: ["json", "yaml", "toml", "javascript", "vue"],
+  package: "eslint-plugin-json-schema-validator-2",
+};
+export const devDependencies = { "eslint-plugin-json-schema-validator-2": "latest" };
+const importName = "jsonSchemaValidator2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import jsonSchemaValidator2 from 'eslint-plugin-json-schema-validator-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-json-schema-validator-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.spread(await helper.x(recommended));
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-remark/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-remark/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-remark";
+export const meta: PluginMeta = {
+  description: "ESLint plugin that runs Remark through ESLint and adds Remark-specific authoring rules.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-remark",
+  lang: ["markdown"],
+  package: "eslint-plugin-remark",
+};
+export const devDependencies = { "eslint-plugin-remark": "latest" };
+const importName = "remark";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import remark from 'eslint-plugin-remark'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-remark" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.spread(await helper.x(recommended));
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-repo/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-repo/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-repo";
+export const meta: PluginMeta = {
+  description: "ESLint rules for repository compliance across common hosting and deployment services.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-repo",
+  lang: ["javascript", "typescript", "json", "yaml"],
+  package: "eslint-plugin-repo",
+};
+export const devDependencies = { "eslint-plugin-repo": "latest" };
+const importName = "repo";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import repo from 'eslint-plugin-repo'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-repo" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-runtime-cleanup/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-runtime-cleanup/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-runtime-cleanup";
+export const meta: PluginMeta = {
+  description: "ESLint rules for requiring cleanup of runtime resources.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-runtime-cleanup",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-runtime-cleanup",
+};
+export const devDependencies = { "eslint-plugin-runtime-cleanup": "latest" };
+const importName = "runtimeCleanup";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import runtimeCleanup from 'eslint-plugin-runtime-cleanup'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-runtime-cleanup" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-sdl-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-sdl-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-sdl-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin providing SDL-focused security and platform hardening rules.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-SDL-2",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-sdl-2",
+};
+export const devDependencies = { "eslint-plugin-sdl-2": "latest" };
+const importName = "sdl2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import sdl2 from 'eslint-plugin-sdl-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-sdl-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.spread(await helper.x(recommended));
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-stylelint-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-stylelint-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-stylelint-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin that runs Stylelint through ESLint and adds Stylelint-specific authoring rules.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-stylelint-2",
+  lang: ["css", "vue"],
+  package: "eslint-plugin-stylelint-2",
+};
+export const devDependencies = { "eslint-plugin-stylelint-2": "latest" };
+const importName = "stylelint2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import stylelint2 from 'eslint-plugin-stylelint-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-stylelint-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.spread(await helper.x(recommended));
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-test-signal/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-test-signal/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-test-signal";
+export const meta: PluginMeta = {
+  description: "ESLint rules that flag weak tests before they become false confidence.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-test-signal",
+  lang: ["javascript", "typescript"],
+  package: "eslint-plugin-test-signal",
+};
+export const devDependencies = { "eslint-plugin-test-signal": "latest" };
+const importName = "testSignal";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import testSignal from 'eslint-plugin-test-signal'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-test-signal" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-tsconfig/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-tsconfig/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-tsconfig";
+export const meta: PluginMeta = {
+  description: "ESLint plugin to catch bad tsconfig compiler-option combos, project reference misconfiguration, and policy drift before tsc.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-tsconfig",
+  lang: ["json"],
+  package: "eslint-plugin-tsconfig",
+};
+export const devDependencies = { "eslint-plugin-tsconfig": "latest" };
+const importName = "tsconfig";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import tsconfig from 'eslint-plugin-tsconfig'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-tsconfig" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-tsdoc-require-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-tsdoc-require-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-tsdoc-require-2";
+export const meta: PluginMeta = {
+  description: "Require TSDoc comments for exported TypeScript declarations.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-tsdoc-require-2",
+  lang: ["typescript"],
+  package: "eslint-plugin-tsdoc-require-2",
+};
+export const devDependencies = { "eslint-plugin-tsdoc-require-2": "latest" };
+const importName = "tsdocRequire2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import tsdocRequire2 from 'eslint-plugin-tsdoc-require-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-tsdoc-require-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-typedoc/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-typedoc/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-typedoc";
+export const meta: PluginMeta = {
+  description: "ESLint rules for TypeDoc documentation quality, validation, and autofix workflows.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-typedoc",
+  lang: ["typescript", "markdown"],
+  package: "eslint-plugin-typedoc",
+};
+export const devDependencies = { "eslint-plugin-typedoc": "latest" };
+const importName = "typedoc";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import typedoc from 'eslint-plugin-typedoc'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-typedoc" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-typefest/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-typefest/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-typefest";
+export const meta: PluginMeta = {
+  description: "ESLint rules for adopting type-fest and ts-extras conventions.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-typefest",
+  lang: ["typescript"],
+  package: "eslint-plugin-typefest",
+};
+export const devDependencies = { "eslint-plugin-typefest": "latest" };
+const importName = "typefest";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import typefest from 'eslint-plugin-typefest'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-typefest" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-vite/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-vite/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-vite";
+export const meta: PluginMeta = {
+  description: "ESLint rules for Vite, Vitest, and Vitest bench configuration and runtime patterns.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-vite",
+  lang: ["javascript", "typescript"],
+  package: "@typpi/eslint-plugin-vite",
+};
+export const devDependencies = { "@typpi/eslint-plugin-vite": "latest" };
+const importName = "vite";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import vite from '@typpi/eslint-plugin-vite'");
+    } else {
+      yield helper.require({ local: importName, source: "@typpi/eslint-plugin-vite" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};

--- a/src/plugins/plugins/nick2bad4u-write-good-comments-2/plugin.ts
+++ b/src/plugins/plugins/nick2bad4u-write-good-comments-2/plugin.ts
@@ -1,0 +1,24 @@
+import type { ESLintConfig, PluginMeta } from "../..";
+
+export const name = "eslint-plugin-write-good-comments-2";
+export const meta: PluginMeta = {
+  description: "ESLint plugin that lints source comments for prose quality, inclusive language, profanity, spelling, readability, and task hygiene.",
+  repo: "https://github.com/Nick2bad4u/eslint-plugin-write-good-comments-2",
+  lang: ["javascript", "typescript", "markdown"],
+  package: "eslint-plugin-write-good-comments-2",
+};
+export const devDependencies = { "eslint-plugin-write-good-comments-2": "latest" };
+const importName = "writeGoodComments2";
+export const eslintConfig: ESLintConfig<typeof importName> = {
+  *imports(helper) {
+    if (helper.type === "module") {
+      yield helper.i("import writeGoodComments2 from 'eslint-plugin-write-good-comments-2'");
+    } else {
+      yield helper.require({ local: importName, source: "eslint-plugin-write-good-comments-2" });
+    }
+  },
+  async *expression(names, helper) {
+    const recommended = names[importName] + ".configs.recommended";
+    yield helper.x(recommended);
+  },
+};


### PR DESCRIPTION
## Summary

- Add plugin installers for Nick2bad4u ESLint plugins so they can be installed from the playground UI.
- Configure each installer to install the published npm package and add its recommended flat config.
- Use the scoped npm package for eslint-plugin-vite: `@typpi/eslint-plugin-vite`.


## Testing

- Not run locally.